### PR TITLE
Remove locale data from locale map when player quit to save ram

### DIFF
--- a/src/main/java/fr/xephi/authme/listener/PlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/PlayerListener.java
@@ -16,9 +16,11 @@ import fr.xephi.authme.service.ValidationService;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.SpawnLoader;
 import fr.xephi.authme.settings.properties.HooksSettings;
+import fr.xephi.authme.settings.properties.PluginSettings;
 import fr.xephi.authme.settings.properties.RegistrationSettings;
 import fr.xephi.authme.settings.properties.RestrictionSettings;
 import fr.xephi.authme.util.TeleportUtils;
+import fr.xephi.authme.util.message.I18NUtils;
 import fr.xephi.authme.util.message.MiniMessageUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -246,6 +248,11 @@ public class PlayerListener implements Listener {
             if (listenerService.shouldCancelEvent(event)) {
                 event.setQuitMessage(null);
             }
+        }
+
+        // Remove data from locale map when player quit
+        if (settings.getProperty(PluginSettings.I18N_MESSAGES)) {
+            I18NUtils.removeLocale(player.getUniqueId());
         }
 
         if (antiBotService.wasPlayerKicked(player.getName())) {

--- a/src/main/java/fr/xephi/authme/util/message/I18NUtils.java
+++ b/src/main/java/fr/xephi/authme/util/message/I18NUtils.java
@@ -60,6 +60,10 @@ public class I18NUtils {
         PLAYER_LOCALE.put(uuid, locale);
     }
 
+    public static void removeLocale(UUID uuid) {
+        PLAYER_LOCALE.remove(uuid);
+    }
+
     /**
      * Returns the AuthMe messages file language code, by given locale and settings.
      * Dreeam - Hard mapping, based on mc1.20.6, 5/29/2024


### PR DESCRIPTION
Remove player locale from locale map when players quit, to avoid unnecessary memory load if AuthMe is used on some large networks for example.