### PR TITLE
Better Regex e-mail

### DIFF
--- a/src/main/java/fr/xephi/authme/settings/properties/RestrictionSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/RestrictionSettings.java
@@ -173,7 +173,7 @@ public final class RestrictionSettings implements SettingsHolder {
 
     @Comment("Regex syntax for allowed chars in email.")
     public static final Property<String> ALLOWED_EMAIL_REGEX =
-        newProperty("settings.restrictions.allowedEmailCharacters", "^([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+)\.([a-zA-Z]{2,})$");
+        newProperty("settings.restrictions.allowedEmailCharacters", "^([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+)\\.([a-zA-Z]{2,})$");
 
 
     @Comment("Force survival gamemode when player joins?")

--- a/src/main/java/fr/xephi/authme/settings/properties/RestrictionSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/RestrictionSettings.java
@@ -173,7 +173,7 @@ public final class RestrictionSettings implements SettingsHolder {
 
     @Comment("Regex syntax for allowed chars in email.")
     public static final Property<String> ALLOWED_EMAIL_REGEX =
-        newProperty("settings.restrictions.allowedEmailCharacters", "^[A-Za-z0-9_.]{3,20}@(qq|outlook|163|gmail|icloud)\\.com$");
+        newProperty("settings.restrictions.allowedEmailCharacters", "^([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+)\.([a-zA-Z]{2,})$");
 
 
     @Comment("Force survival gamemode when player joins?")


### PR DESCRIPTION
The current Regex e-mail doesn't account for people in other countries (for example, in my country `@seznam.cz` is a popular e-mail!) or custom e-mails at that (`@luketeam5.xyz`)

I think it's better to allow any valid-looking e-mail addresses as default rather than restrict to popular mail providers only.
If someone wants to restrict to g-mail, outlook, ... they can do so manually, that's what the config is for after all.
But should allow all e-mail out of the box.