### PR TITLE
优化插件加载时的 MySQL 日志输出，解决 HikariCP 日志问题

### DIFF
--- a/src/main/java/fr/xephi/authme/datasource/MySQL.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySQL.java
@@ -129,6 +129,9 @@ public class MySQL extends AbstractSqlDataSource {
      * Sets up the connection arguments to the database.
      */
     private void setConnectionArguments() {
+        System.setProperty("fr.xephi.authme.libs.org.slf4j.simpleLogger.defaultLogLevel", "warn");
+        logger.info("AuthMeMYSQLPool - Starting...");
+
         ds = new HikariDataSource();
         ds.setPoolName("AuthMeMYSQLPool");
 


### PR DESCRIPTION
本次 PR 旨在优化 AuthMe 插件加载过程中 MySQL 数据库连接的日志输出，解决由 HikariCP 库引起的不规范日志行为。
**优化之前:**
```log
[14:26:39] [Server thread/INFO]: [AuthMe] Enabling AuthMe v5.7.0-FORK-b53
[14:26:39] [Server thread/INFO]: [AuthMe] You are running an unofficial fork version of AuthMe!
[14:26:40] [Server thread/INFO]: [AuthMe] Connection arguments loaded, Hikari ConnectionPool ready!
[14:26:40] [Server thread/ERROR]: [AuthMe] [STDERR] [Server thread] INFO fr.xephi.authme.libs.com.zaxxer.hikari.HikariDataSource - AuthMeMYSQLPool - Starting...
[14:26:40] [Server thread/WARN]: Nag author(s): '[sgdc3, games647, Hex3l, krusic22]' of 'AuthMe v5.7.0-FORK-b53' about their usage of System.out/err.print. Please use your plugin's logger instead (JavaPlugin#getLogger).
[14:26:41] [Server thread/ERROR]: [AuthMe] [STDERR] [Server thread] INFO fr.xephi.authme.libs.com.zaxxer.hikari.HikariDataSource - AuthMeMYSQLPool - Start completed.
[14:26:41] [Server thread/INFO]: [AuthMe] MySQL setup finished
```
**优化之后:**
```log
[16:18:45] [Server thread/INFO]: [AuthMe] Enabling AuthMe v5.7.0-FORK-b53
[16:18:45] [Server thread/INFO]: [AuthMe] You are running an unofficial fork version of AuthMe!
[16:18:46] [Server thread/INFO]: [AuthMe] AuthMeMYSQLPool - Starting...
[16:18:46] [Server thread/INFO]: [AuthMe] Connection arguments loaded, Hikari ConnectionPool ready!
[16:18:46] [Server thread/INFO]: [com.zaxxer.hikari.HikariDataSource] AuthMeMYSQLPool - Starting...
[16:18:46] [Server thread/INFO]: [com.zaxxer.hikari.pool.HikariPool] AuthMeMYSQLPool - Added connection com.mysql.cj.jdbc.ConnectionImpl@40976474
[16:18:46] [Server thread/INFO]: [com.zaxxer.hikari.HikariDataSource] AuthMeMYSQLPool - Start completed.
[16:18:46] [Server thread/INFO]: [AuthMe] MySQL setup finished
```
**优化原因:**

1.  **消除 Spigot/Paper 的 "Nag author" 警告:**
    优化前，HikariCP 内部使用的 SLF4J (SimpleLogger) 默认将日志输出到 `System.err`（标准错误流）。在 Bukkit/Spigot 环境下，这会触发服务器的监控机制，产生“Nag author”警告，提示开发者不应直接使用 `System.out/err`，而是应该使用插件自带的 `Logger`。本次修改成功消除了这一警告，提升了插件的兼容性和专业形象。

2.  **修复日志级别误报:**
    优化前，HikariCP 的 `INFO` 级别日志（如 `Starting...` 和 `Start completed.`）被非规范地重定向到了 `STDERR`，导致服务器控制台将其错误地标记为 `[ERROR]`。本次修改纠正了这一问题，使这些信息以正确的 `[INFO]` 级别显示，避免了服主对数据库连接状态产生误解。

3.  **提升日志规范性 (部分实现):**
    根据 Bukkit 插件开发规范，所有输出应通过 `java.util.logging.Logger` 进行。本次修改通过设置系统属性 `fr.xephi.authme.libs.org.slf4j.simpleLogger.defaultLogLevel` 为 `warn`，成功阻止了第三方库通过 `System.err` 进行的非规范输出。此外，AuthMe 自身关于数据库连接的重要提示现在通过插件的 `ConsoleLogger` 正确记录，避免了对 `System.out/err` 的直接使用。虽然部分 HikariCP 内部的 `INFO` 级别日志仍然存在，但最严重的违规行为已得到解决。

4.  **显著提升控制台信息清晰度:**
    本次优化彻底移除了服务器对非规范日志产生的 `[ERROR]` 和 `[WARN]` 标记，使控制台输出不再出现误报的错误信息和烦人的“Nag author”警告。这使得启动日志更加干净、易于理解和排查，为服主提供了更良好的使用体验。